### PR TITLE
Fix commands table

### DIFF
--- a/docs/LocalhostSetup.md
+++ b/docs/LocalhostSetup.md
@@ -217,6 +217,8 @@ The stakes have already been deposited for these Addresses so you can now move o
 
 ### Starting the Miners and Data Server
 You can do this in 6 separate terminals locally. Run each of the command in each of the terminals and confirm they start up correctly.
+
+
 | Terminal # | Command                                                  | Description    |
 |------------|----------------------------------------------------------|----------------|
 | 1          | ./TellorMiner --config=config-dataserver.json dataserver | Data Server    |


### PR DESCRIPTION
I think this will fix the [broken table](https://tellor.readthedocs.io/en/latest/LocalhostSetup/#conclusion) at the bottom of the docs when they render on readthedocs.